### PR TITLE
Smol fix for AIO

### DIFF
--- a/pages/server/development/aio.mdx
+++ b/pages/server/development/aio.mdx
@@ -58,7 +58,7 @@ For a free server:
 </DiscordMessages>
 <br></br>
 For a donator server:
-<DiscordMessages no-background>
+<DiscordMessages>
   <DiscordMessage
     author="Jonfirexbox"
     avatar="https://avatars.githubusercontent.com/u/66625200?v=4"


### PR DESCRIPTION
AIO page didn't have the `no-background` setting off for dono version.
![tfzYcs](https://github.com/user-attachments/assets/b0a50b77-b511-4857-bb2d-8320ffd6acb9)
