### PR TITLE
feat(theme): Removed “Noise” background

### DIFF
--- a/components/layout/component.tsx
+++ b/components/layout/component.tsx
@@ -16,7 +16,7 @@ import { Header } from "@component/header";
 import { Navbar } from "@component/navbar";
 import { RouterTransition } from "@component/progress";
 import { Footer } from "@component/footer";
-import Noise from "@public/noise.svg";
+//import Noise from "@public/noise.svg";
 
 import { colors, components, focusRingStyles, mdxComponents } from "./config";
 import { MDXProvider } from "@mdx-js/react";
@@ -102,7 +102,7 @@ export const PanelProvider: FunctionComponent<
                   ? theme.colors.dark[9]
                   : theme.white,
             },
-            ".noise": {
+            /*".noise": {
               backgroundImage: `url(${Noise.src})`,
               backgroundRepeat: "repeat",
               mixBlendMode: theme.colorScheme === "dark" ? "darken" : "screen",
@@ -118,7 +118,7 @@ export const PanelProvider: FunctionComponent<
               // Ignore noise
               position: "relative",
               zIndex: 20,
-            },
+            },*/
           }),
         }}
       >

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docs.danbot.host",
-  "version": "2.1.0",
-  "description": "",
+  "version": "2.1.2",
+  "description": "The documentaion site for DanBot Hosting",
   "main": "next.config.js",
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
In this PR we have removed the `noise.svg` file from the background and will no longer make the discord styled messages have a strange background.

Thank you for the help @CuteDog5695 (Helped by making this suggestion)